### PR TITLE
static positioning of footer

### DIFF
--- a/www/bootstrap.css
+++ b/www/bootstrap.css
@@ -60,9 +60,10 @@ background: #5ee;
 }
 
 @media (max-width: 767px) {
-	#footer { 
-        display : none; 
-        visibility : hidden; 
+    #footer { 
+        display : block;
+        position: static;
+        height: auto;
     }
 }
 


### PR DESCRIPTION
Rather than hide the footer on tablets, keep it and just position statically underneath the rest of the body.

I haven't checked this on a browser so might have to fix up some styles etc. but basically fixed positioning can be horrible, so I might also suggest some CSS hacks to put the footer at the bottom of the screen but allow it to sit below all of the content - that way if someone is viewing the page on a stupid screen size, it doesn't take up all of the space (they might have a wide, but short window) in which case the footer would just get in the way.

http://matthewjamestaylor.com/blog/keeping-footers-at-the-bottom-of-the-page

(I assume you're using fix to bottom so the footer doesn't appear in the middle of the page anyway...)