### PR TITLE
Features/create variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ data/Surveys/*.svydesign
 rsconnect
 .vscode
 
+# renv files
+.Rprofile
+renv.lock
+renv/
+
 # Created by https://www.toptal.com/developers/gitignore/api/r,macos,windows,linux
 # Edit at https://www.toptal.com/developers/gitignore?templates=r,macos,windows,linux
 

--- a/functions.R
+++ b/functions.R
@@ -1522,6 +1522,20 @@ get.quantiles = function(subx){
   g1
 }
 
+#' Make Syntactically Valid Names
+#'
+#' @param names vector to be coerced to syntactically valid names.
+#' 
+#' @description Replace spaces with underscores and any other 
+#' invalid characters to dots
+#' 
+#' @return Character vector of valid names
+make_names = function(names) {
+  names = gsub("\\s+", "_", names)
+  names = make.names(names)
+  
+  return(names)
+}
 
 #' Loads data from a specified URL
 #'

--- a/panels/E4_CreateVariables/2_create.variables.panel.server.R
+++ b/panels/E4_CreateVariables/2_create.variables.panel.server.R
@@ -41,9 +41,7 @@ observe({
        input$create.variables.submit>0){
       # check if the new variable contains spaces " " or dashes "-"
       # replace it with an underscore "_" if found
-      # browser()
-      new_var = trimws(input$create.variables.name)
-      new_var = gsub(" |-", "_", new_var)
+      new_var = make_names(input$create.variables.name)
       
       temp = iNZightTools::createNewVar(get.data.set(),
                                         new_var = new_var,

--- a/panels/E4_CreateVariables/2_create.variables.panel.server.R
+++ b/panels/E4_CreateVariables/2_create.variables.panel.server.R
@@ -39,8 +39,14 @@ observe({
   isolate({
     if(!is.null(input$create.variables.submit)&&
        input$create.variables.submit>0){
+      # check if the new variable contains spaces " " or dashes "-"
+      # replace it with an underscore "_" if found
+      # browser()
+      new_var = trimws(input$create.variables.name)
+      new_var = gsub(" |-", "_", new_var)
+      
       temp = iNZightTools::createNewVar(get.data.set(),
-                                        new_var = input$create.variables.name,
+                                        new_var = new_var,
                                         get.create.variables.expression.text())
       if(!is.null(temp)){
         updatePanel$datachanged = updatePanel$datachanged+1


### PR DESCRIPTION
Fixes #277 

Replaces dashes `"-"` and spaces `" "` with underscores `"_"` when variables are created. I.e.,

- `h-ello` to `h_ello`
- `he llo` to `he_llo`
- `h-ell o` to `h_ell_o`