### PR TITLE
fix(app): Fix issue in num.bars that could result in duplicated bars

### DIFF
--- a/functions.R
+++ b/functions.R
@@ -1296,10 +1296,7 @@ help.display = function(title, id, file) {
              <h4 class='modal-title' id='myModalLabel'>",title,"</h4>
              </div>
              <div class='modal-body'>",
-             markdownToHTML(
-               file = file,
-               options = c(""),
-               stylesheet = "www/empty.css"),
+             mark_html(file = file),
              "</div>
              <div class='modal-footer'>
              </div>
@@ -1525,15 +1522,15 @@ get.quantiles = function(subx){
 #' Make Syntactically Valid Names
 #'
 #' @param names vector to be coerced to syntactically valid names.
-#' 
-#' @description Replace spaces with underscores and any other 
+#'
+#' @description Replace spaces with underscores and any other
 #' invalid characters to dots
-#' 
+#'
 #' @return Character vector of valid names
 make_names = function(names) {
   names = gsub("\\s+", "_", names)
   names = make.names(names)
-  
+
   return(names)
 }
 

--- a/panels/C1_Visualize/2_visualize-panel-server.R
+++ b/panels/C1_Visualize/2_visualize-panel-server.R
@@ -577,6 +577,7 @@ observe({
     ## fix the axis limit bug
     plot.par$xlim = NULL
     plot.par$ylim = NULL
+    plot.par$zoombars = NULL
     graphical.par$plottype = "default"
   })
 })
@@ -587,6 +588,7 @@ observe({
     ## fix the axis limit bug
     plot.par$xlim = NULL
     plot.par$ylim = NULL
+    plot.par$zoombars = NULL
     graphical.par$plottype = "default"
   })
 })


### PR DESCRIPTION
Clear the par$zoombars argument when switching V1/V2 to resolve a bug that could cause duplicated bars.