### PR TITLE
fix(server): Add missing field to survey spec object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 - FIX: Provides a temporary fix for an issue caused by passing invalid(?) values of 'varnames' to gg_* plottypes - there are other instances (e.g., colby, sizeby, etc), and further testing/investigation needed.
 
+- FIX: bug in survey calibration specification
+
 # Release 1.0.4
 
 - Fixes a bug in survey imports with functions moved from iNZightTools to surveyspec

--- a/functions.R
+++ b/functions.R
@@ -1296,10 +1296,7 @@ help.display = function(title, id, file) {
              <h4 class='modal-title' id='myModalLabel'>",title,"</h4>
              </div>
              <div class='modal-body'>",
-             markdownToHTML(
-               file = file,
-               options = c(""),
-               stylesheet = "www/empty.css"),
+             mark_html(file = file),
              "</div>
              <div class='modal-footer'>
              </div>
@@ -1525,15 +1522,15 @@ get.quantiles = function(subx){
 #' Make Syntactically Valid Names
 #'
 #' @param names vector to be coerced to syntactically valid names.
-#' 
-#' @description Replace spaces with underscores and any other 
+#'
+#' @description Replace spaces with underscores and any other
 #' invalid characters to dots
-#' 
+#'
 #' @return Character vector of valid names
 make_names = function(names) {
   names = gsub("\\s+", "_", names)
   names = make.names(names)
-  
+
   return(names)
 }
 

--- a/panels/D6_SurveyDesign/2_survey.design.server.R
+++ b/panels/D6_SurveyDesign/2_survey.design.server.R
@@ -165,7 +165,8 @@ setDesign <- function(x) {
           scale = x$scale,
           rscales = x$rscales,
           type = x$type,
-          calibrate = x$calibrate
+          calibrate = x$calibrate,
+          calfun = if (is.null(x$calibrate)) NULL else "linear"
         )
       ),
       class = "inzsvyspec"


### PR DESCRIPTION
Add missing `calfun` field to the survey spec argument, which was preventing specification of post stratification information.