### PR TITLE
Fix plot graphics device leaks on main visualize paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iNZightLite
 Type: Shiny Application
 Title: iNZight Lite
-Version: 2026.01.8
+Version: 2026.05.1
 Authors@R: c(
     person("Charco", "Hui", role = c("aut", "cre"),
         email = "charco.hui@auckland.ac.nz"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# 2026.05.1
+
+## Fixes
+
+- Fix graphics devices not always being closed on the main and interactive plot paths, which could eventually trigger a "too many open devices" error when plotting.
+
 # 2026.01.3
 
 - Prevent non-fatal tab error during app startup

--- a/functions.R
+++ b/functions.R
@@ -12,6 +12,36 @@ read_config <- function() {
   fromJSON(lite_config)
 }
 
+#' Open pdf(NULL), run expr, always dev.off() (including on error).
+with_null_pdf_device <- function(expr) {
+  pdf(NULL)
+  on.exit(dev.off(), add = TRUE)
+  force(expr)
+}
+
+#' Open a file plot device, run expr, always dev.off() (including on error).
+with_plot_file_device <- function(file, type = c("png", "pdf", "jpg"), expr) {
+  type <- match.arg(type)
+  switch(type,
+    png = png(file),
+    pdf = pdf(file, useDingbats = FALSE, onefile = FALSE),
+    jpg = jpeg(file)
+  )
+  on.exit(dev.off(), add = TRUE)
+  force(expr)
+}
+
+#' Close graphics devices opened during expr; leaves pre-existing devices (e.g. Shiny renderPlot).
+with_extra_device_cleanup <- function(expr) {
+  n_before <- length(dev.list())
+  on.exit({
+    while (length(dev.list()) > n_before) {
+      dev.off(length(dev.list()))
+    }
+  }, add = TRUE)
+  force(expr)
+}
+
 # Modified based off:
 # https://github.com/dreamRs/shinylogs/blob/0195ac0a1f85d213c82143cfee712c9baddd1963/R/tracking.R#L134
 init_lite_logs <- function(

--- a/functions.R
+++ b/functions.R
@@ -33,12 +33,15 @@ with_plot_file_device <- function(file, type = c("png", "pdf", "jpg"), expr) {
 
 #' Close graphics devices opened during expr; leaves pre-existing devices (e.g. Shiny renderPlot).
 with_extra_device_cleanup <- function(expr) {
-  n_before <- length(dev.list())
-  on.exit({
-    while (length(dev.list()) > n_before) {
-      dev.off(length(dev.list()))
-    }
-  }, add = TRUE)
+  devices_before <- dev.list()
+  on.exit(
+    {
+      for (dev in setdiff(dev.list(), devices_before)) {
+        dev.off(dev)
+      }
+    },
+    add = TRUE
+  )
   force(expr)
 }
 

--- a/panels/C1_Visualize/2_visualize-panel-server.R
+++ b/panels/C1_Visualize/2_visualize-panel-server.R
@@ -1217,6 +1217,7 @@ observe({
 })
 
 output$visualize.plot <- renderPlot({
+  with_extra_device_cleanup({
   isolate({
     # some of the graphical parameters need
     # to be reminded what there default
@@ -1296,10 +1297,12 @@ output$visualize.plot <- renderPlot({
       }
     }
   }
+  })
 })
 
 
 output$mini.plot <- renderPlot({
+  with_extra_device_cleanup({
   isolate({
     # some of the graphical parameters need
     # to be reminded what their default
@@ -1364,6 +1367,7 @@ output$mini.plot <- renderPlot({
       }
     }
   }
+  })
 })
 
 ##  Reset variable selection and graphical parameters.
@@ -3248,13 +3252,10 @@ output$plotly_inter <- renderPlotly({
         new_par <- new_vis_par(vis_par = temp)
       }
 
-      pdf(NULL)
-      # do.call(iNZightPlots:::iNZightPlot, temp)
-      do.call(iNZightPlots:::inzplot, new_par)
-
-      g <- plotly::ggplotly()
-      dev.off()
-      g
+      with_null_pdf_device({
+        do.call(iNZightPlots:::inzplot, new_par)
+        plotly::ggplotly()
+      })
     }
   })
 })
@@ -3286,14 +3287,10 @@ output$plotly_nw <- renderUI({
       # set to temp directory
       tdir <- tempdir()
       setwd(tdir)
-      pdf(NULL)
-      cdev <- dev.cur()
-      on.exit(dev.off(cdev), add = TRUE)
-      # do.call(iNZightPlots:::iNZightPlot, temp)
-      do.call(iNZightPlots:::inzplot, new_par)
-
-      htmlwidgets::saveWidget(as_widget(plotly::ggplotly()), "index.html")
-      dev.off()
+      with_null_pdf_device({
+        do.call(iNZightPlots:::inzplot, new_par)
+        htmlwidgets::saveWidget(as_widget(plotly::ggplotly()), "index.html")
+      })
       addResourcePath("path", normalizePath(tdir))
       list(
         br(),
@@ -6408,14 +6405,12 @@ output$saveplot <- downloadHandler(
   },
   content = function(file) {
     if (input$saveplottype %in% c("jpg", "png", "pdf")) {
-      if (input$saveplottype == "jpg") {
-        jpeg(file)
-      } else if (input$saveplottype == "png") {
-        png(file)
-      } else if (input$saveplottype == "pdf") {
-        pdf(file, useDingbats = FALSE, onefile = F)
-      }
-
+      plot_type <- switch(input$saveplottype,
+        jpg = "jpg",
+        png = "png",
+        pdf = "pdf"
+      )
+      with_plot_file_device(file, plot_type, {
       if (!is.null(vis.par())) {
         dafr <- get.data.set()
         if (!is.null(plot.par$x) && !is.null(input$vari1) &&
@@ -6467,7 +6462,7 @@ output$saveplot <- downloadHandler(
           }
         }
       }
-      dev.off()
+      })
     } else if (input$saveplottype == "svg") {
       local.dir <- exportSVG.function(create.html)
       src <- normalizePath(local.dir)
@@ -6492,28 +6487,21 @@ exportSVG <- function(x, file, ...) {
 exportSVG.function <- function(x, file = "inzightplot.svg",
                                width = dev.size()[1],
                                height = dev.size()[2], ...) {
-  # get current directory
   curdir <- getwd()
-
-  # set directory to temp directory
   tdir <- tempdir()
   setwd(tdir)
+  on.exit(setwd(curdir), add = TRUE)
 
-  # create pdf graphics device into here:
   pdf("tempfile.pdf", width = width, height = height, onefile = TRUE)
+  on.exit({
+    dev.off()
+    if (file.exists("tempfile.pdf")) {
+      file.remove("tempfile.pdf")
+    }
+  }, add = TRUE)
 
-  # do exporting:
   obj <- x()
   exportSVG(obj, file)
-
-  # turn off device:
-  dev.off()
-
-  # remove pdf:
-  file.remove("tempfile.pdf")
-
-  # reset back to original directory:
-  setwd(curdir)
 }
 
 
@@ -7460,6 +7448,7 @@ observe({
   input$refreshplot
   isolate({
     output$visualize.plot <- renderPlot({
+      with_extra_device_cleanup({
       isolate({
         # some of the graphical parameters need
         # to be reminded what there default
@@ -7520,6 +7509,7 @@ observe({
           }
         }
       }
+      })
     })
   })
 })


### PR DESCRIPTION
Add safe device wrappers and use them for renderPlot, plotly, save plot, and SVG export so devices are always closed. Bump version to 2026.05.1.